### PR TITLE
Compile options

### DIFF
--- a/examples/co_oxidation_ruo2_processes_paired__build.py
+++ b/examples/co_oxidation_ruo2_processes_paired__build.py
@@ -437,4 +437,5 @@ kmc_model.print_statistics()
 kmc_model.backend = 'local_smart' #specifying is optional. 'local_smart' is the default. Currently, the other options are 'lat_int' and 'otf'
 kmc_model.clear_model(model_name=kmc_model.model_name, backend=kmc_model.backend) #This line is optional: if you are updating a model, this line will remove the old model files (including compiled files) before exporting the new one. It is convenient to always include this line because then you don't need to 'confirm' removing/overwriting the old model during the compile step.
 kmc_model.save_model()
+kmc_model.compile_options = ' -t '
 kmcos.compile(kmc_model)

--- a/kmcos/__init__.py
+++ b/kmcos/__init__.py
@@ -55,7 +55,7 @@ from __future__ import print_function
 #import kmcos.types
 #import kmcos.io
 
-__version__ = "0.0.61"
+__version__ = "0.0.63"
 VERSION = __version__
 
 def evaluate_param_expression(param, parameters={}):
@@ -442,7 +442,7 @@ def evaluate_rate_expression(rate_expr, parameters={}):
 
 def compile(kmc_model): #exports the kmc_model.xml file
     import kmcos
-    kmcos.export(kmc_model.filename + ' -b' + kmc_model.backend)
+    kmcos.export(kmc_model.filename + ' -b' + kmc_model.backend + ' ' + kmc_model.compile_options) # You can find these various compile_options in get_options() in kmcos/cli.py
 
 def create_kmc_model(model_name = None): #pointer to create_kmc_model in types.py, which creates the kmc_model
     from kmcos.types import create_kmc_model

--- a/kmcos/cli.py
+++ b/kmcos/cli.py
@@ -170,7 +170,8 @@ def get_options(args=None, get_parser=False):
         + ') [options]',
         version=kmcos.__version__)
 
-    parser.add_option('-s', '--source-only',
+    # -s is the shorthamd for --source-only. All following options follow the same syntax
+    parser.add_option('-s', '--source-only', 
                       dest='source_only',
                       action='store_true',
                       default=False)

--- a/kmcos/types.py
+++ b/kmcos/types.py
@@ -85,8 +85,10 @@ class Project(object):
         self.meta = Meta()
         if type(model_name)==type(None):
             self.model_name = "UntitledModel"
+            self.meta.model_name = "UntitledModel"
         else:
             self.model_name = model_name
+            self.meta.model_name = model_name
         self.layer_list = LayerList()
         self.lattice = self.layer_list
         self.parameter_list = ParameterList()
@@ -95,6 +97,7 @@ class Project(object):
         self.output_list = OutputList()
         self.filename = self.model_name + ".xml"
         self.backend = "local_smart" #this is just the default.
+        self.compile_options = ""
 
         # Quick'n'dirty define access functions
         # needed in context with GTKProject
@@ -565,8 +568,9 @@ class Project(object):
         with open('abbreviations_{}.dat'.format(self.meta.model_name), 'w') as outfile:
             outfile.write(pprint.pformat(stub_map))
 
-    def clear_model(self, model_name, backend=''):
+    def clear_model(self, model_name='', backend=''):
         if backend=='': backend = self.backend
+        if model_name=='': model_name = self.model_name
         import kmcos.io
         kmcos.io.clear_model(model_name, backend=backend)
     

--- a/tests/accelerated_tests/CO_oxidation_Ruo2__acc_backend__do_acc_steps.py
+++ b/tests/accelerated_tests/CO_oxidation_Ruo2__acc_backend__do_acc_steps.py
@@ -444,4 +444,4 @@ kmc_model.backend = 'local_smart' #specifying is optional. local_smart is the df
 kmc_model.clear_model() #This line is optional: if you are updating a model, this line will remove the old model before exporting the new one. It is convenent to always include this line because then you don't need to 'confirm' removing the old model.
 kmc_model.save_model()
 kmc_model.compile_options =  ' -t ' #should be '' if acceleration is not desired. 
-kmcos.export(kmc_model.filename + ' -b ' + kmc_model.backend + ' ' + kmc_model.compile_options) #alternatively, one can use: kmcos.cli.main('export '+  kmc_model.filename + ' -b' + kmc_model.backend)
+kmcos.compile(kmc_model) #alternatively, one can use: kmcos.cli.main('export '+  kmc_model.filename + ' -b' + kmc_model.backend)

--- a/tests/accelerated_tests/CO_oxidation_Ruo2__acc_backend__do_acc_steps.py
+++ b/tests/accelerated_tests/CO_oxidation_Ruo2__acc_backend__do_acc_steps.py
@@ -441,7 +441,7 @@ import kmcos
 ###It's good to simply copy and paste the below lines between model creation files.
 kmc_model.filename = model_name + ".xml"
 kmc_model.backend = 'local_smart' #specifying is optional. local_smart is the dfault. Currently, the other options are 'lat_int' and 'otf'
-kmc_model.clear_model(model_name, backend=kmc_model.backend) #This line is optional: if you are updating a model, this line will remove the old model before exporting the new one. It is convenent to always include this line because then you don't need to 'confirm' removing the old model.
+kmc_model.clear_model() #This line is optional: if you are updating a model, this line will remove the old model before exporting the new one. It is convenent to always include this line because then you don't need to 'confirm' removing the old model.
 kmc_model.save_model()
-acceleration =  ' -t ' #should be '' if acceleration is not desired. 
-kmcos.export(kmc_model.filename + ' -b ' + kmc_model.backend + acceleration) #alternatively, one can use: kmcos.cli.main('export '+  kmc_model.filename + ' -b' + kmc_model.backend)
+kmc_model.compile_options =  ' -t ' #should be '' if acceleration is not desired. 
+kmcos.export(kmc_model.filename + ' -b ' + kmc_model.backend + ' ' + kmc_model.compile_options) #alternatively, one can use: kmcos.cli.main('export '+  kmc_model.filename + ' -b' + kmc_model.backend)

--- a/tests/accelerated_tests/CO_oxidation_Ruo2__acc_backend__do_steps.py
+++ b/tests/accelerated_tests/CO_oxidation_Ruo2__acc_backend__do_steps.py
@@ -444,5 +444,5 @@ kmc_model.filename = model_name + ".xml"
 kmc_model.backend = 'local_smart' #specifying is optional. local_smart is the dfault. Currently, the other options are 'lat_int' and 'otf'
 kmc_model.clear_model(model_name, backend=kmc_model.backend) #This line is optional: if you are updating a model, this line will remove the old model before exporting the new one. It is convenent to always include this line because then you don't need to 'confirm' removing the old model.
 kmc_model.save_model()
-acceleration =  ' -t ' #should be '' if acceleration is not desired. 
-kmcos.export(kmc_model.filename + ' -b ' + kmc_model.backend + acceleration) #alternatively, one can use: kmcos.cli.main('export '+  kmc_model.filename + ' -b' + kmc_model.backend)
+kmc_model.compile_options =  ' -t ' #should be '' if acceleration is not desired.  
+kmcos.compile(kmc_model) #alternatively, one can use: kmcos.cli.main('export '+  kmc_model.filename + ' -b' + kmc_model.backend)

--- a/tests/accelerated_tests/CO_oxidation_Ruo2__non_acc_backend__do_steps.py
+++ b/tests/accelerated_tests/CO_oxidation_Ruo2__non_acc_backend__do_steps.py
@@ -444,4 +444,4 @@ kmc_model.filename = model_name + ".xml"
 kmc_model.backend = 'local_smart' #specifying is optional. local_smart is the dfault. Currently, the other options are 'lat_int' and 'otf'
 kmc_model.clear_model(model_name, backend=kmc_model.backend) #This line is optional: if you are updating a model, this line will remove the old model before exporting the new one. It is convenent to always include this line because then you don't need to 'confirm' removing the old model.
 kmc_model.save_model()
-kmcos.export(kmc_model.filename + ' -b ' + kmc_model.backend) #alternatively, one can use: kmcos.cli.main('export '+  kmc_model.filename + ' -b' + kmc_model.backend)
+kmcos.compile(kmc_model) #alternatively, one can use: kmcos.cli.main('export '+  kmc_model.filename + ' -b' + kmc_model.backend)


### PR DESCRIPTION
Changes to kmcos.compile() function to accept optional compile_options. Three test files in test/acceleration and examples/co_oxidation_ruo2_processes_paired__build reflect those changes.