### PR TITLE
Appends Process Names Greater than 30 to Text File

### DIFF
--- a/kmcos/__init__.py
+++ b/kmcos/__init__.py
@@ -50,7 +50,7 @@ from __future__ import print_function
 
 
 
-__version__ = "0.0.69"
+__version__ = "0.0.70"
 VERSION = __version__
 
 def evaluate_param_expression(param, parameters={}):

--- a/kmcos/types.py
+++ b/kmcos/types.py
@@ -580,6 +580,7 @@ class Project(object):
         kmcos.io.clear_model(model_name, backend=backend)
     
     def save_model(self, filename="", validate=True):
+        import sys
         self.model_name = self.meta.model_name
         #If the user provides a filename, save_model will use that. Otherwise, save_model will create a default filename with the model_name
         if len(filename) == 0:
@@ -597,8 +598,10 @@ class Project(object):
             raise UserWarning('Cannot export to file suffix %s' %
                               os.path.splitext(self.filename)[-1])
 
+        #If there are errors with the model object, then write the list of errors to a .log file
         if len(self.error_list) > 0:
-            np.savetxt(filename+"_error.txt", self.error_list, delimiter=", ", fmt="%s")
+            np.savetxt(sys.argv[0][0:-3]+".log", self.error_list, delimiter=", ", fmt="%s", header = "Type, Name, Message")
+
 
     def save(self, filename="", validate=True):
         self.save_model(filename, validate)

--- a/kmcos/types.py
+++ b/kmcos/types.py
@@ -98,6 +98,7 @@ class Project(object):
         self.filename = self.model_name + ".xml"
         self.backend = "local_smart" #this is just the default.
         self.compile_options = ""
+        self.error_list = []
 
         # Quick'n'dirty define access functions
         # needed in context with GTKProject
@@ -198,6 +199,10 @@ class Project(object):
                 kwargs.pop('actions')
             process = Process(**kwargs)
             self.process_list.append(process)
+
+            if 'name' in kwargs:
+                if len(kwargs['name']) > 30:
+                    self.error_list.append(tuple(("Process Name", kwargs['name'], "Process name should not be longer than 30 characters, otherwise the Fortran compiler may raise errors")))
         return process
 
     def parse_process(self, string):
@@ -592,6 +597,8 @@ class Project(object):
             raise UserWarning('Cannot export to file suffix %s' %
                               os.path.splitext(self.filename)[-1])
 
+        if len(self.error_list) > 0:
+            np.savetxt(filename+"_error.txt", self.error_list, delimiter=", ", fmt="%s")
 
     def save(self, filename="", validate=True):
         self.save_model(filename, validate)

--- a/kmcos/types.py
+++ b/kmcos/types.py
@@ -580,7 +580,6 @@ class Project(object):
         kmcos.io.clear_model(model_name, backend=backend)
     
     def save_model(self, filename="", validate=True):
-        import sys
         self.model_name = self.meta.model_name
         #If the user provides a filename, save_model will use that. Otherwise, save_model will create a default filename with the model_name
         if len(filename) == 0:
@@ -600,7 +599,7 @@ class Project(object):
 
         #If there are errors with the model object, then write the list of errors to a .log file
         if len(self.error_list) > 0:
-            np.savetxt(sys.argv[0][0:-3]+".log", self.error_list, delimiter=", ", fmt="%s", header = "Type, Name, Message")
+            np.savetxt(self.model_name+"__build.log", self.error_list, delimiter=", ", fmt="%s", header = "Type, Name, Message")
 
 
     def save(self, filename="", validate=True):


### PR DESCRIPTION
Allows users to see what process name values could cause errors when building a model due to Fortran restrictions.

[//]: # (If your pull request is a fix to an open issue please add fixes #9999 to the commit comments.)
[//]: # (If your proposal involves GUI improvements, add screenshots of before and after to help visualise the proposal on the fly.)
#### Changes proposed
